### PR TITLE
Update example release.yml in GitHub Actions documentation

### DIFF
--- a/docs/publishing/release-your-plugin-with-github-actions.md
+++ b/docs/publishing/release-your-plugin-with-github-actions.md
@@ -21,81 +21,47 @@ The GitHub Action workflow was originally created and shared by [argentum](https
 
    jobs:
      build:
-       runs-on: ubuntu-latest
+      runs-on: ubuntu-latest
 
-       steps:
-         - uses: actions/checkout@v2
-         - name: Use Node.js
-           uses: actions/setup-node@v1
-           with:
-             node-version: "14.x"
+      steps:
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+        - name: Use Node.js
+          uses: actions/setup-node@v1
+          with:
+            node-version: "14.x" # You might need to adjust this value to your own version
 
-         - name: Build
-           id: build
-           run: |
-             npm install
-             npm run build
-             mkdir ${{ env.PLUGIN_NAME }}
-             cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
-             zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
-             ls
-             echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"
+        # Get the version number and put it in an environment file
+        - name: Get Version
+          id: version
+          run: |
+            echo "tag=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_ENV
 
-         - name: Create Release
-           id: create_release
-           uses: actions/create-release@v1
-           env:
-             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-             VERSION: ${{ github.ref }}
-           with:
-             tag_name: ${{ github.ref }}
-             release_name: ${{ github.ref }}
-             draft: false
-             prerelease: false
+        # Build the plugin
+        - name: Build
+          id: build
+          run: |
+            npm install
+            npm run build --if-present
 
-         - name: Upload zip file
-           id: upload-zip
-           uses: actions/upload-release-asset@v1
-           env:
-             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           with:
-             upload_url: ${{ steps.create_release.outputs.upload_url }}
-             asset_path: ./${{ env.PLUGIN_NAME }}.zip
-             asset_name: ${{ env.PLUGIN_NAME }}-${{ steps.build.outputs.tag_name }}.zip
-             asset_content_type: application/zip
+        # Package the required files into a zip
+        - name: Package
+          run: |
+            mkdir ${{ github.event.repository.name }}
+            cp main.js manifest.json styles.css README.md ${{ github.event.repository.name }}
+            zip -r ${{ github.event.repository.name }}-${{ env.tag }}.zip ${{ github.event.repository.name }}
 
-         - name: Upload main.js
-           id: upload-main
-           uses: actions/upload-release-asset@v1
-           env:
-             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           with:
-             upload_url: ${{ steps.create_release.outputs.upload_url }}
-             asset_path: ./main.js
-             asset_name: main.js
-             asset_content_type: text/javascript
+        - name: Release
+          uses: softprops/action-gh-release@v1
+          with:
+            files: |
+              ${{ github.event.repository.name }}-${{ env.tag }}.zip
+              main.js
+              main.css
+              manifest.json
+              styles.css
 
-         - name: Upload manifest.json
-           id: upload-manifest
-           uses: actions/upload-release-asset@v1
-           env:
-             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           with:
-             upload_url: ${{ steps.create_release.outputs.upload_url }}
-             asset_path: ./manifest.json
-             asset_name: manifest.json
-             asset_content_type: application/json
-
-         - name: Upload styles.css
-           id: upload-css
-           uses: actions/upload-release-asset@v1
-           env:
-             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           with:
-             upload_url: ${{ steps.create_release.outputs.upload_url }}
-             asset_path: ./styles.css
-             asset_name: styles.css
-             asset_content_type: text/css
    ```
 
 1. In your terminal, commit the workflow.
@@ -161,7 +127,6 @@ To enable standard-version for your plugin:
    ```
 
    - `"t": ""` configures standard-version to remove the default `v` prefix to adhere to Obsidian's guidelines.
-
 
 To make a release:
 


### PR DESCRIPTION
I've just made a few changes here:

1.  The `Build` and `Package` steps have been separated in line with the [discussion](https://forum.obsidian.md/t/using-github-actions-to-release-plugins/7877/3) linked in the documentation.

2. GitHub has [deprecated the set-output command](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). I updated that call on line 39 in the new version to use an [environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files).

3. `actions/upload-release-asset` is no longer maintained. The ReadMe in the [repo for that action](https://github.com/actions/upload-release-asset) suggests using [softprops/action-gh-release](https://github.com/softprops/action-gh-release) instead which does shorten the code up quite a bit as it allows uploading all assets in one action rather than one action per asset.

I have this pipeline live in [my fork](https://github.com/afhoffman/workflow-experiments) of [dethau's](https://github.com/deathau/workflow-experiments) workflow-experiments repo.