### PR TITLE
Filling in some missing steps, adding a resource, and clarifications.

### DIFF
--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -18,6 +18,13 @@ If you run into a problem, it can be helpful to see how others have solved it. B
 - [luckman212/obsidian-plugin-downloader](https://github.com/luckman212/obsidian-plugin-downloader)
 - [claremacrae/obsidian-repos-downloader](https://github.com/claremacrae/obsidian-repos-downloader)
 
+## Search the code of all plugins remotely
+
+You can also dig through the code of all public Obsidian plugins without needing to download them on your device.
+
+- GitHub allows you to search source code using its native search tools, although this can be a bit finnicky.
+- [Sourcegraph](https://sourcegraph.com/search) is much more powerful and greatly simplifies the process of searching through all public repos.
+
 ## Beta testing
 
 Before you [publish](publishing/submit-your-plugin.md) your plugin, you may want to let users try it out first.

--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -22,8 +22,12 @@ If you run into a problem, it can be helpful to see how others have solved it. B
 
 You can also dig through the code of all public Obsidian plugins without needing to download them on your device.
 
-- GitHub allows you to search source code using its native search tools, although this can be a bit finicky.
-- [Sourcegraph](https://sourcegraph.com/search) is much more powerful and greatly simplifies the process of searching through all public repos.
+- GitHub allows you to search source code hosted on their site using its native search tools.
+- [Sourcegraph](https://sourcegraph.com/search) allows you to search source code in public repos across the web, including GitHub.
+
+By using advanced search tools to filter by language (TypeScript) and including "Obsidian" in the search, you can usually narrow your results down to code snippets from Obsidian plugins. It helps if you're searching for an example of some specific part of the Obsidian API. 
+
+For more general examples of how plugins are structured, you can simply locate and browse the repository of any plugin here on GitHub.
 
 ## Beta testing
 

--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -22,7 +22,7 @@ If you run into a problem, it can be helpful to see how others have solved it. B
 
 You can also dig through the code of all public Obsidian plugins without needing to download them on your device.
 
-- GitHub allows you to search source code using its native search tools, although this can be a bit finnicky.
+- GitHub allows you to search source code using its native search tools, although this can be a bit finicky.
 - [Sourcegraph](https://sourcegraph.com/search) is much more powerful and greatly simplifies the process of searching through all public repos.
 
 ## Beta testing

--- a/docs/getting-started/create-your-first-plugin.md
+++ b/docs/getting-started/create-your-first-plugin.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 # Create your first plugin
 
-In this guide, you'll build a plugin for Obsidian. If you prefer a video walk-through, check out [Create Your Own Obsidian Plugin](https://www.youtube.com/watch?v=9lA-jaMNS0k) by [Antone Heyward](https://www.youtube.com/channel/UC9w43btR2UUsfR6ZUf3AlqQ).
+In this guide, you'll build a plugin for Obsidian. If you prefer a video walk-through, check out [Create Your Own Obsidian Plugin](https://www.youtube.com/watch?v=9lA-jaMNS0k) by [Antone Heyward](https://www.youtube.com/channel/UC9w43btR2UUsfR6ZUf3AlqQ), or [How to Create an Obsidian Plugin](https://www.youtube.com/watch?v=XaES2G3PVpg) by [Phibr0](https://github.com/phibr0) as part of [Obsidian Community Talks](https://www.youtube.com/@obsidiancommunitytalks9199).
 
 :::warning Before you start
 **Don't develop plugins in your main vault.** When you develop a plugin, one mistake can lead to unintentional modifications to your vault. You also risk **permanently deleting your vault**.
@@ -17,6 +17,8 @@ To complete this guide, you will need:
 - [Git](https://git-scm.com/) installed on your local machine.
 - A [GitHub](https://github.com) account.
 - A local development environment for [Node.js](https://Node.js.org/en/about/).
+
+If you wish to use Yarn instead of npm, you will also need [Yarn](https://yarnpkg.com/) installed on your local machine.
 
 ## Step 1 — Download the sample plugin
 
@@ -97,7 +99,7 @@ A plugin is also a Node.js package, which you can configure in the `package.json
 
 ## Step 5 — Update the source code
 
-In this step, you'll make a change to the source code and reload the plugin to reflect your change.
+In this step, you'll make a change to the source code.
 
 1. Open `main.ts` in your editor.
 1. Find the lines of code that adds a _ribbon icon_.
@@ -114,8 +116,33 @@ In this step, you'll make a change to the source code and reload the plugin to r
    new Notice('Hello, you!');
    ```
 
-1. Restart Obsidian to reload your plugin.
-1. Click the die icon in the sidebar. Make sure it says "Sample Plugin" when you hover it.
+1. Save the changes you have made.
+
+
+## Step 6 — Compile the updated source code
+
+If `dev` is still running in the background, your changes will be detected and re-compiled automatically, so you can skip this step.
+
+If `dev` is not still running in the background, you will need to follow these earlier steps to run it again and compile your changes:
+
+1. Navigate into the plugin folder.
+
+   ```bash
+   cd path/to/vault/.obsidian/plugins/obsidian-instant-coffee
+   ```
+
+1. Compile the source code. The following command generates a `main.js` that contains the compiled version of your plugin.
+
+   ```bash npm2yarn
+   npm run dev
+   ```
+
+## Step 7 — Reload the plugin
+
+1. Restart Obsidian or toggle your plugin off/on (disabled/enabled) to reload it.
+1. Find the correct die icon in the sidebar. It should say "Sample Plugin" when you hover over it.
+1. Click the die icon.
+1. You should see a notice pop up with the new text you added.
 
 ## Next steps
 

--- a/docs/getting-started/create-your-first-plugin.md
+++ b/docs/getting-started/create-your-first-plugin.md
@@ -4,7 +4,7 @@ sidebar_position: 10
 
 # Create your first plugin
 
-In this guide, you'll build a plugin for Obsidian. If you prefer a video walk-through, check out [Create Your Own Obsidian Plugin](https://www.youtube.com/watch?v=9lA-jaMNS0k) by [Antone Heyward](https://www.youtube.com/channel/UC9w43btR2UUsfR6ZUf3AlqQ), or [How to Create an Obsidian Plugin](https://www.youtube.com/watch?v=XaES2G3PVpg) by [Phibr0](https://github.com/phibr0) as part of [Obsidian Community Talks](https://www.youtube.com/@obsidiancommunitytalks9199).
+In this guide, you'll build a plugin for Obsidian. If you prefer a video walk-through, check out [Create Your Own Obsidian Plugin](https://www.youtube.com/watch?v=9lA-jaMNS0k) by [Antone Heyward](https://www.youtube.com/channel/UC9w43btR2UUsfR6ZUf3AlqQ) or [How to create a plugin for Obsidian](https://www.youtube.com/watch?v=XaES2G3PVpg) by [@phibr0](https://github.com/phibr0).
 
 :::warning Before you start
 **Don't develop plugins in your main vault.** When you develop a plugin, one mistake can lead to unintentional modifications to your vault. You also risk **permanently deleting your vault**.


### PR DESCRIPTION
I filled in these missing steps that would cause dead-ends when trying to follow the "Create your first plugin" tutorial:

1. Yarn must be installed on your system before you can use the `yarn` commands mentioned via the `npm2yarn` code blocks, as it does not come with NodeJS. I also tried to clarify that either can be used, as the tutorial implies you need to use both simultaneously in its current state. I placed it outside the bullet list to reinforce that it's not mandatory as the other steps are.

2. The project must be built before you can see the changes reflected in Obsidian. I think it was assumed the user would leave the `yarn/npm run dev` running in the background and re-start it between development sessions, but not all users will know they need to do that. The last step was broken down into a couple more to better clarify the process.

I also added another YouTube video walkthrough of creating a plugin, found on the Obsidian Community Talks channel. This one is more recent and takes a similar approach to the text tutorial.

I also added other minor clarifications and tips.