### PR TITLE
adjust default value for `createContext` example

### DIFF
--- a/docs/getting-started/react.md
+++ b/docs/getting-started/react.md
@@ -110,7 +110,7 @@ Another alternative is to create a React context for the app to make it globally
    import * as React from "react";
    import { App } from 'obsidian';
 
-   export const AppContext = React.createContext<App>(undefined);
+   export const AppContext = React.createContext<App>({} as App);
    ```
 
 1. Wrap the `ReactView` with a context provider and pass the app as the value.


### PR DESCRIPTION
passing in `undefined` here throws the following error:
```
TS2345: Argument of type 'undefined' is not assignable to parameter of type 'App'.
```
I propose this type cast instead, even though not the most elegant solution, it avoids the error, as the context is already set in initialization of the React context.