### PR TITLE
ci: replace set-output with env files

### DIFF
--- a/docs/publishing/release-your-plugin-with-github-actions.md
+++ b/docs/publishing/release-your-plugin-with-github-actions.md
@@ -39,7 +39,8 @@ The GitHub Action workflow was originally created and shared by [argentum](https
              cp main.js manifest.json styles.css ${{ env.PLUGIN_NAME }}
              zip -r ${{ env.PLUGIN_NAME }}.zip ${{ env.PLUGIN_NAME }}
              ls
-             echo "::set-output name=tag_name::$(git tag --sort version:refname | tail -n 1)"
+             git_tag=$(git tag --sort version:refname | tail -n 1)
+             echo "tag_name=$git_tag" >> "$GITHUB_ENV"
 
          - name: Create Release
            id: create_release


### PR DESCRIPTION
`set-output-commands` will be deactivated on **31st May 2023**. 

Announcement: [github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
> We are monitoring telemetry for the usage of these commands and plan to fully disable them on **31st May 2023**. Starting 1st June 2023 workflows using save-state or set-output commands via stdout will fail with an error.

How to: [docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)